### PR TITLE
Update uri.php

### DIFF
--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -62,6 +62,17 @@ class JUri extends Uri
 			// Are we obtaining the URI from the server?
 			if ($uri == 'SERVER')
 			{
+				/* Determine if the SSL was offloaded at a load balancer.
+				  https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+				  X-Forwarded-Proto: https 
+				  A de facto standard for identifying the originating protocol of an HTTP request, 
+				  since a reverse proxy (load balancer) may communicate with a web server using HTTP 
+				  even if the request to the reverse proxy is HTTPS. 				 
+				*/
+                                if(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'){
+                                        $_SERVER['HTTPS']='on';
+                                }
+                                
 				// Determine if the request was over SSL (HTTPS).
 				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
 				{


### PR DESCRIPTION
When SSL is offloaded (or SSL termination) by a load balancer, the redirect to force HTTPS is handled by the web server by using the X-Forwarded-proto X header. When using Amazon Elastic Load Balancers, you can terminate SSL and direct all traffic to non secure port on the server. If you also use $force_ssl on Joomla it causes a redirect loop. This code will allow Joomla to detect the X header if it is set by a load balancer.

https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
X-Forwarded-Proto: https 
A de facto standard for identifying the originating protocol of an HTTP request, 
since a reverse proxy (load balancer) may communicate with a web server using HTTP 
 even if the request to the reverse proxy is HTTPS.